### PR TITLE
refactor: add skeleton loader and brown theme

### DIFF
--- a/nosabos/src/App.css
+++ b/nosabos/src/App.css
@@ -12,10 +12,10 @@
   transition: filter 300ms;
 }
 .logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
+  filter: drop-shadow(0 0 2em #b56576aa);
 }
 .logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+  filter: drop-shadow(0 0 2em #e0aaffaa);
 }
 
 @keyframes logo-spin {

--- a/nosabos/src/App.jsx
+++ b/nosabos/src/App.jsx
@@ -1,6 +1,7 @@
 // App.jsx
 import { useEffect, useRef, useState, useMemo } from "react";
 import { doc, getDoc, setDoc } from "firebase/firestore";
+import { Box, Skeleton, SkeletonText } from "@chakra-ui/react";
 
 import "./App.css";
 import VoiceChat from "./components/VoiceChat";
@@ -206,7 +207,24 @@ export default function App() {
 
   // Loading state while we fetch/create the user doc
   if (isLoadingApp || !user) {
-    return <div style={{ padding: 16, color: "#e2e8f0" }}>Loading…</div>;
+    return (
+      <Box p={4} maxW="480px" mx="auto">
+        <Skeleton
+          height="40px"
+          mb={4}
+          startColor="#d7ccc8"
+          endColor="#f5e0d3"
+          borderRadius="md"
+        />
+        <SkeletonText
+          noOfLines={4}
+          spacing={4}
+          skeletonHeight={3}
+          startColor="#e0c9b9"
+          endColor="#f7ede2"
+        />
+      </Box>
+    );
   }
 
   // First-run: show Onboarding (saves progress + flips flag)

--- a/nosabos/src/components/Onboarding.jsx
+++ b/nosabos/src/components/Onboarding.jsx
@@ -204,7 +204,7 @@ export default function Onboarding({ npub = "", onComplete }) {
               {/* Submit */}
               <Button
                 size="lg"
-                colorScheme="teal"
+                colorScheme="orange"
                 onClick={handleStart}
                 isLoading={isSaving}
                 loadingText="Saving"

--- a/nosabos/src/components/RobotBuddyPro.jsx
+++ b/nosabos/src/components/RobotBuddyPro.jsx
@@ -73,7 +73,7 @@ export default function RobotBuddyPro({
   loudness = 0,
   speakLoudness,
   variant = "abstract",
-  palette = "ocean",
+  palette = "sunset",
   showBadges = true,
   compact = false,
   maxW = 420,
@@ -160,7 +160,7 @@ export default function RobotBuddyPro({
             <Badge
               colorScheme={
                 state === "listening"
-                  ? "cyan"
+                  ? "orange"
                   : state === "speaking"
                   ? "green"
                   : state === "thinking"
@@ -175,7 +175,7 @@ export default function RobotBuddyPro({
             {mood !== "neutral" && (
               <Badge
                 variant="subtle"
-                colorScheme="teal"
+                colorScheme="orange"
                 fontSize={compact ? "xs" : "sm"}
               >
                 {mood}
@@ -700,7 +700,7 @@ function CharacterAvatar({ amp, state, mood, colors, reduced }) {
           stroke={colors.stroke}
           strokeWidth="2"
         />
-        <rect x="66" y="50" width="228" height="48" rx="12" fill="#0b1220" />
+        <rect x="66" y="50" width="228" height="48" rx="12" fill="#2a1a14" />
 
         <g stroke={accent} strokeWidth="3" strokeLinecap="round" opacity="0.8">
           {mood === "encourage" ? (

--- a/nosabos/src/components/VoiceChat.jsx
+++ b/nosabos/src/components/VoiceChat.jsx
@@ -266,12 +266,12 @@ const MOBILE_TEXT_SX = {
     Phrase-aligned highlighting
   --------------------------- */
 const COLORS = [
-  "#91E0FF",
-  "#A0EBAF",
-  "#FFD48A",
-  "#C6B7FF",
-  "#FF9FB1",
-  "#B0F0FF",
+  "#D2B48C",
+  "#E6B89C",
+  "#FFDAB9",
+  "#CDB4DB",
+  "#FFB6C1",
+  "#F3E5AB",
 ];
 const colorFor = (i) => COLORS[i % COLORS.length];
 
@@ -1276,7 +1276,7 @@ export default function VoiceChat({
                 <Wrap spacing={2}>
                   {vocab.slice(0, 8).map((w, i) => (
                     <WrapItem key={i}>
-                      <Tag colorScheme="teal" variant="subtle" maxW="100%">
+                      <Tag colorScheme="orange" variant="subtle" maxW="100%">
                         {w}
                       </Tag>
                     </WrapItem>
@@ -1289,7 +1289,7 @@ export default function VoiceChat({
               <Text fontSize="xs" opacity={0.8}>
                 Pronunciation / Grammar / Vocab / Fluency
               </Text>
-              <Progress value={pct} size="sm" colorScheme="teal" rounded="sm" />
+              <Progress value={pct} size="sm" colorScheme="orange" rounded="sm" />
             </Box>
 
             <Stack direction={["column", "row"]} spacing={2}>
@@ -1350,7 +1350,7 @@ export default function VoiceChat({
               </Badge>
             </WrapItem>
             <WrapItem>
-              <Badge colorScheme="teal" variant="subtle">
+              <Badge colorScheme="orange" variant="subtle">
                 XP {xp}
               </Badge>
             </WrapItem>
@@ -1408,7 +1408,7 @@ export default function VoiceChat({
               </Text>
             </Box>
             <Badge
-              colorScheme="teal"
+              colorScheme="orange"
               whiteSpace="normal" // allow wrapping inside the badge on mobile
               alignSelf={["flex-start", "flex-start", "flex-start", "center"]}
               maxW="100%"
@@ -1564,7 +1564,7 @@ export default function VoiceChat({
                 mt={1}
                 value={progressPct}
                 size="xs"
-                colorScheme="teal"
+                colorScheme="orange"
                 rounded="sm"
               />
             </Stat>
@@ -1576,7 +1576,7 @@ export default function VoiceChat({
               height="64px"
               px="8"
               rounded="full"
-              colorScheme="teal"
+              colorScheme="orange"
               boxShadow="0 10px 30px rgba(0,0,0,0.35)"
             >
               🎤 Talk
@@ -1796,7 +1796,7 @@ export default function VoiceChat({
                     isLoading={isSwitching}
                     loadingText="Switching"
                     onClick={switchAccount}
-                    colorScheme="teal"
+                    colorScheme="orange"
                   >
                     Switch
                   </Button>

--- a/nosabos/src/index.css
+++ b/nosabos/src/index.css
@@ -1,7 +1,7 @@
 html,
 body {
-  background-color: #0b1220 !important;
-  color: #e5e7eb !important; /* gray.100 */
+  background-color: #f5e0d3 !important;
+  color: #4b2e2a !important;
 }
 
 :root {
@@ -9,9 +9,9 @@ body {
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  color-scheme: light;
+  color: #4b2e2a;
+  background-color: #f5e0d3;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -21,11 +21,11 @@ body {
 
 a {
   font-weight: 500;
-  color: #646cff;
+  color: #a47148;
   text-decoration: inherit;
 }
 a:hover {
-  color: #535bf2;
+  color: #8d5a32;
 }
 
 body {
@@ -48,12 +48,12 @@ button {
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
+  background-color: #e8d5c4;
   cursor: pointer;
   transition: border-color 0.25s;
 }
 button:hover {
-  border-color: #646cff;
+  border-color: #a47148;
 }
 button:focus,
 button:focus-visible {
@@ -62,13 +62,13 @@ button:focus-visible {
 
 @media (prefers-color-scheme: light) {
   :root {
-    color: #213547;
-    background-color: #ffffff;
+    color: #4b2e2a;
+    background-color: #f5e0d3;
   }
   a:hover {
-    color: #747bff;
+    color: #8d5a32;
   }
   button {
-    background-color: #f9f9f9;
+    background-color: #e8d5c4;
   }
 }


### PR DESCRIPTION
## Summary
- replace text-based loading screen with skeleton loader
- switch global styling to warmer brown palette
- retheme controls and bot colors to orange/brown hues

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68af823f5c38832687bbf0663c7470a8