### PR TITLE
Honor onboarding practice language choice

### DIFF
--- a/nosabos/src/App.jsx
+++ b/nosabos/src/App.jsx
@@ -152,7 +152,10 @@ export default function App() {
           : "en",
         voice: safe(payload.voice, "Leda"),
         voicePersona: safe(payload.voicePersona, DEFAULT_PERSONA),
-        targetLang: payload.targetLang === "nah" ? "nah" : "es",
+        // Preserve user selection; default to Spanish if unset
+        targetLang: ["nah", "es"].includes(payload.targetLang)
+          ? payload.targetLang
+          : "es",
         showTranslations:
           typeof payload.showTranslations === "boolean"
             ? payload.showTranslations


### PR DESCRIPTION
## Summary
- Persist user's selected practice language from onboarding, defaulting to Spanish only when unspecified
- Initialize and hydrate VoiceChat with the saved practice language instead of forcing Náhuatl
- Initialize target language from user store so VoiceChat respects onboarding choice immediately
- Prevent profile hydration from overwriting the stored practice language
- Use stored user id to load and save conversation turns, preserving chat history across refreshes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint src/App.jsx`
- `npx eslint src/components/VoiceChat.jsx` *(fails: Empty block statement, no-unused-vars, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68af94a0d86c8326a68f5ac2adfecf9a