### PR TITLE
Fix theme toggle positioning and improve onboarding text styling

### DIFF
--- a/nosabos/src/App.jsx
+++ b/nosabos/src/App.jsx
@@ -1490,7 +1490,7 @@ function TopBar({
                             ? t.teams_feed_allow_enabled ||
                               "Automatic community posts enabled."
                             : t.teams_feed_allow_disabled ||
-                          "Automatic community posts disabled."}
+                              "Automatic community posts disabled."}
                         </Text>
                       </Box>
 
@@ -5323,7 +5323,8 @@ export default function App() {
   const onboardingInitialDraft = {
     ...(user?.progress || {}),
     ...(user?.onboarding?.draft || {}),
-    themeMode: user?.onboarding?.draft?.themeMode || user?.themeMode || themeMode,
+    themeMode:
+      user?.onboarding?.draft?.themeMode || user?.themeMode || themeMode,
   };
 
   if (needsOnboarding) {
@@ -5874,7 +5875,11 @@ export default function App() {
             </VStack>
           </ModalBody>
           <ModalFooter gap={3} flexWrap="wrap">
-            <Button variant="ghost" color="white" onClick={handleTimeUpButtonClose}>
+            <Button
+              variant="ghost"
+              color="white"
+              onClick={handleTimeUpButtonClose}
+            >
               {t.timer_times_up_close || "Close"}
             </Button>
             <Button
@@ -6595,7 +6600,9 @@ function BottomActionBar({
                 />
                 <Portal>
                   <MenuList
-                    bg={isLightTheme ? "var(--app-surface-elevated)" : "gray.800"}
+                    bg={
+                      isLightTheme ? "var(--app-surface-elevated)" : "gray.800"
+                    }
                     color={isLightTheme ? "var(--app-text-primary)" : "white"}
                     borderColor="var(--app-border)"
                     boxShadow="var(--app-shadow-soft)"

--- a/nosabos/src/components/LinksPage.jsx
+++ b/nosabos/src/components/LinksPage.jsx
@@ -137,13 +137,16 @@ const ThemeModeToggle = ({ themeMode, onModeChange }) => {
 
   return (
     <Box
-      position="fixed"
-      top="18px"
-      right={{ base: "16px", md: "20px" }}
-      left="auto"
-      width="fit-content"
-      maxW="calc(100vw - 32px)"
-      zIndex={120}
+      style={{
+        position: "fixed",
+        top: "18px",
+        right: "16px",
+        left: "auto",
+        bottom: "auto",
+        width: "fit-content",
+        maxWidth: "calc(100vw - 32px)",
+        zIndex: 120,
+      }}
     >
       <HStack
         spacing="3px"
@@ -154,6 +157,7 @@ const ThemeModeToggle = ({ themeMode, onModeChange }) => {
         borderColor={APP_BORDER}
         boxShadow={APP_SHADOW}
         backdropFilter="blur(20px)"
+        display="inline-flex"
         width="fit-content"
         flexShrink={0}
       >

--- a/nosabos/src/components/LinksPage.jsx
+++ b/nosabos/src/components/LinksPage.jsx
@@ -140,6 +140,9 @@ const ThemeModeToggle = ({ themeMode, onModeChange }) => {
       position="fixed"
       top="18px"
       right={{ base: "16px", md: "20px" }}
+      left="auto"
+      width="fit-content"
+      maxW="calc(100vw - 32px)"
       zIndex={120}
     >
       <HStack
@@ -151,6 +154,8 @@ const ThemeModeToggle = ({ themeMode, onModeChange }) => {
         borderColor={APP_BORDER}
         boxShadow={APP_SHADOW}
         backdropFilter="blur(20px)"
+        width="fit-content"
+        flexShrink={0}
       >
         {modes.map((mode) => {
           const isActive = themeMode === mode.id;

--- a/nosabos/src/components/Onboarding.jsx
+++ b/nosabos/src/components/Onboarding.jsx
@@ -668,7 +668,7 @@ export default function Onboarding({
                     <>
                       <Box bg="gray.800" p={3} rounded="md">
                         <HStack justifyContent="space-between">
-                          <Text fontSize="sm">
+                          <Text fontSize="sm" fontWeight="semibold" color="var(--app-text-primary)">
                             {ui.sound_effects_label || "Sound effects"}
                           </Text>
                           <Switch


### PR DESCRIPTION
## Summary
This PR addresses layout and styling issues in the theme mode toggle component and improves text styling in the onboarding flow.

## Key Changes
- **ThemeModeToggle positioning fixes:**
  - Added `left="auto"` to ensure the toggle stays on the right side
  - Added `width="fit-content"` and `maxW="calc(100vw - 32px)"` to the Box wrapper to prevent overflow on smaller screens
  - Added `width="fit-content"` and `flexShrink={0}` to the HStack to maintain proper sizing and prevent unwanted shrinking

- **Onboarding sound effects label styling:**
  - Added `fontWeight="semibold"` to make the label more prominent
  - Added `color="var(--app-text-primary)"` to ensure consistent text color with the app's theme

## Implementation Details
These changes ensure the theme toggle component is properly constrained on mobile devices while maintaining its fixed positioning, and improve the visual hierarchy of the sound effects label in the onboarding screen by making it bolder and ensuring it uses the correct theme color.

https://claude.ai/code/session_012aLBC2BS6gJBuyhRddDSiK