### PR TITLE
Adjust landing page subtitle font size scaling

### DIFF
--- a/nosabos/src/components/LandingPage.jsx
+++ b/nosabos/src/components/LandingPage.jsx
@@ -1299,7 +1299,7 @@ const LandingPage = ({ onAuthenticated }) => {
             transition={{ delay: 0.5 }}
             style={{
               fontFamily: theme.fonts.body,
-              fontSize: "clamp(0.8rem, 1.5vw, 0.9rem)",
+              fontSize: "clamp(0.7rem, 1.2vw, 0.8rem)",
               color: theme.colors.text.secondary,
               maxWidth: "580px",
               margin: "0 auto 32px",

--- a/nosabos/src/components/LandingPage.jsx
+++ b/nosabos/src/components/LandingPage.jsx
@@ -1299,7 +1299,7 @@ const LandingPage = ({ onAuthenticated }) => {
             transition={{ delay: 0.5 }}
             style={{
               fontFamily: theme.fonts.body,
-              fontSize: "clamp(0.95rem, 2vw, 1.1rem)",
+              fontSize: "clamp(0.8rem, 1.5vw, 0.9rem)",
               color: theme.colors.text.secondary,
               maxWidth: "580px",
               margin: "0 auto 32px",


### PR DESCRIPTION
## Summary
Updated the font size clamp values for the landing page subtitle text to use smaller, more constrained sizing.

## Changes
- Modified the `fontSize` clamp function from `clamp(0.95rem, 2vw, 1.1rem)` to `clamp(0.8rem, 1.5vw, 0.9rem)`
  - Reduced minimum font size from 0.95rem to 0.8rem
  - Reduced viewport width scaling from 2vw to 1.5vw
  - Reduced maximum font size from 1.1rem to 0.9rem

## Details
This change constrains the subtitle text to a smaller size range with less aggressive scaling relative to viewport width. The adjustment ensures the subtitle remains more compact across different screen sizes while maintaining readability.

https://claude.ai/code/session_01Ueo5Ey6ta21MMY7zBp8qon