### PR TITLE
Optimize session timer rendering with external store

### DIFF
--- a/nosabos/src/App.jsx
+++ b/nosabos/src/App.jsx
@@ -156,6 +156,11 @@ import {
 } from "./utils/flashcardReview";
 import { RiArrowLeftLine } from "react-icons/ri";
 import SessionTimerModal from "./components/SessionTimerModal";
+import SessionTimerBadge from "./components/SessionTimerBadge";
+import {
+  getRemainingSeconds,
+  setRemainingSeconds,
+} from "./provider/SessionTimerProvider";
 import ProficiencyTestModal from "./components/ProficiencyTestModal";
 import GettingStartedModal from "./components/GettingStartedModal";
 import BitcoinSupportModal from "./components/BitcoinSupportModal";
@@ -534,10 +539,9 @@ function TopBar({
   viewMode,
 
   // 🆕 timer props
-  timerRemainingSeconds,
+  hasTimer,
   isTimerRunning,
   timerPaused,
-  formatTimer,
   onOpenTimerModal,
   onTogglePauseTimer,
   // 🆕 daily goal modal props
@@ -973,22 +977,7 @@ function TopBar({
               ml="auto"
               align="center"
             >
-              {timerRemainingSeconds !== null && (
-                <Badge
-                  colorScheme={isTimerRunning ? "teal" : "purple"}
-                  variant="subtle"
-                  px={3}
-                  py={1.5}
-                  borderRadius="md"
-                  display="flex"
-                  alignItems="center"
-                  gap={2}
-                >
-                  <Text fontFamily="mono" fontWeight="bold" fontSize="2xs">
-                    {formatTimer(timerRemainingSeconds)}
-                  </Text>
-                </Badge>
-              )}
+              {hasTimer && <SessionTimerBadge isRunning={isTimerRunning} />}
               <Button
                 colorScheme="teal"
                 variant={isTimerRunning ? "solid" : "outline"}
@@ -1000,7 +989,7 @@ function TopBar({
               >
                 <FiClock />
               </Button>
-              {timerRemainingSeconds !== null && (
+              {hasTimer && (
                 <Button
                   colorScheme="teal"
                   variant={timerPaused ? "outline" : "ghost"}
@@ -2458,23 +2447,26 @@ export default function App() {
 
   /* -----------------------------------
      Session timer
+     The high-frequency "remaining seconds" value is kept in a module-level
+     store (SessionTimerProvider) so only <SessionTimerBadge/> re-renders on
+     each 1-second tick. App and TopBar only re-render on structural changes
+     (start, pause, reset, time-up).
   ----------------------------------- */
   const [timerModalOpen, setTimerModalOpen] = useState(false);
   const [timerMinutes, setTimerMinutes] = useState("20");
-  const [timerRemainingSeconds, setTimerRemainingSeconds] = useState(null);
   const [timerDurationSeconds, setTimerDurationSeconds] = useState(null);
   const [timerActive, setTimerActive] = useState(false);
   const [timerPaused, setTimerPaused] = useState(false);
   const [timerEndsAt, setTimerEndsAt] = useState(null);
   const [timeUpOpen, setTimeUpOpen] = useState(false);
+  const [hasTimer, setHasTimer] = useState(false);
   const timerIntervalRef = useRef(null);
   const timerHydratedRef = useRef(false);
   const sessionTimerStorageKey = useMemo(
     () => `${SESSION_TIMER_STORAGE_KEY}:${activeNpub || "anonymous"}`,
     [activeNpub],
   );
-  const isTimerRunning =
-    timerActive && !timerPaused && timerRemainingSeconds !== null;
+  const isTimerRunning = timerActive && !timerPaused && hasTimer;
 
   useEffect(() => {
     if (timeUpOpen) {
@@ -2570,13 +2562,6 @@ export default function App() {
     proficiencyTestOpen,
   ]);
 
-  const formatTimer = useCallback((seconds) => {
-    const safe = Math.max(0, Math.floor(Number(seconds) || 0));
-    const mins = String(Math.floor(safe / 60)).padStart(2, "0");
-    const secs = String(safe % 60).padStart(2, "0");
-    return `${mins}:${secs}`;
-  }, []);
-
   useEffect(() => {
     timerHydratedRef.current = false;
 
@@ -2589,12 +2574,13 @@ export default function App() {
       const raw = window.sessionStorage.getItem(sessionTimerStorageKey);
       if (!raw) {
         setTimerMinutes("20");
-        setTimerRemainingSeconds(null);
+        setRemainingSeconds(null);
         setTimerDurationSeconds(null);
         setTimerActive(false);
         setTimerPaused(false);
         setTimerEndsAt(null);
         setTimeUpOpen(false);
+        setHasTimer(false);
         return;
       }
 
@@ -2617,11 +2603,12 @@ export default function App() {
         Number.isFinite(storedRemaining) &&
         storedRemaining > 0
       ) {
-        setTimerRemainingSeconds(storedRemaining);
+        setRemainingSeconds(storedRemaining);
         setTimerActive(true);
         setTimerPaused(true);
         setTimerEndsAt(null);
         setTimeUpOpen(false);
+        setHasTimer(true);
         return;
       }
 
@@ -2632,17 +2619,19 @@ export default function App() {
         );
 
         if (nextRemaining > 0) {
-          setTimerRemainingSeconds(nextRemaining);
+          setRemainingSeconds(nextRemaining);
           setTimerActive(true);
           setTimerPaused(false);
           setTimerEndsAt(storedEndsAt);
           setTimeUpOpen(false);
+          setHasTimer(true);
         } else {
-          setTimerRemainingSeconds(0);
+          setRemainingSeconds(0);
           setTimerActive(false);
           setTimerPaused(false);
           setTimerEndsAt(null);
           setTimeUpOpen(true);
+          setHasTimer(true);
         }
       }
     } catch (error) {
@@ -2656,11 +2645,13 @@ export default function App() {
     if (!timerHydratedRef.current || typeof window === "undefined") return;
 
     try {
+      // While running we persist only endsAt (remaining is recomputed on
+      // hydrate). While paused we snapshot remaining so it survives reload.
       window.sessionStorage.setItem(
         sessionTimerStorageKey,
         JSON.stringify({
           minutes: timerMinutes,
-          remainingSeconds: timerRemainingSeconds,
+          remainingSeconds: timerPaused ? getRemainingSeconds() : null,
           durationSeconds: timerDurationSeconds,
           active: timerActive,
           paused: timerPaused,
@@ -2672,7 +2663,6 @@ export default function App() {
     }
   }, [
     timerMinutes,
-    timerRemainingSeconds,
     timerDurationSeconds,
     timerActive,
     timerPaused,
@@ -2710,10 +2700,11 @@ export default function App() {
     }
     setTimerActive(false);
     setTimerPaused(false);
-    setTimerRemainingSeconds(null);
+    setRemainingSeconds(null);
     setTimerDurationSeconds(null);
     setTimerEndsAt(null);
     setTimeUpOpen(false);
+    setHasTimer(false);
   }, []);
 
   const handleStartTimer = useCallback(() => {
@@ -2722,12 +2713,13 @@ export default function App() {
     const seconds = parsedMinutes * 60;
     const endsAt = Date.now() + seconds * 1000;
     setTimerDurationSeconds(seconds);
-    setTimerRemainingSeconds(seconds);
+    setRemainingSeconds(seconds);
     setTimerActive(true);
     setTimerPaused(false);
     setTimerEndsAt(endsAt);
     setTimeUpOpen(false);
     setTimerModalOpen(false);
+    setHasTimer(true);
     if (shouldShowProficiencyAfterTimer) {
       setShouldShowProficiencyAfterTimer(false);
       setProficiencyTestOpen(true);
@@ -2737,20 +2729,22 @@ export default function App() {
   const handleCloseTimeUp = useCallback(() => {
     playSound(selectSound);
     setTimeUpOpen(false);
-    setTimerRemainingSeconds(null);
+    setRemainingSeconds(null);
     setTimerDurationSeconds(null);
     setTimerActive(false);
     setTimerPaused(false);
     setTimerEndsAt(null);
+    setHasTimer(false);
   }, [playSound]);
 
   const clearTimeUpState = useCallback(() => {
     setTimeUpOpen(false);
-    setTimerRemainingSeconds(null);
+    setRemainingSeconds(null);
     setTimerDurationSeconds(null);
     setTimerActive(false);
     setTimerPaused(false);
     setTimerEndsAt(null);
+    setHasTimer(false);
   }, []);
 
   const handleTimeUpButtonClose = useCallback(() => {
@@ -2764,11 +2758,6 @@ export default function App() {
     setTimerModalOpen(true);
   }, [clearTimeUpState, playSound]);
 
-  const timerHelper = useMemo(() => {
-    if (timerRemainingSeconds === null) return null;
-    return null;
-  }, [formatTimer, timerActive, timerRemainingSeconds]);
-
   useEffect(() => {
     if (!timerActive || timerPaused || !Number.isFinite(timerEndsAt)) return;
 
@@ -2777,7 +2766,9 @@ export default function App() {
         0,
         Math.ceil((timerEndsAt - Date.now()) / 1000),
       );
-      setTimerRemainingSeconds(nextRemaining);
+      // Writes to the module-level store and notifies only subscribers
+      // (SessionTimerBadge). App and TopBar do NOT re-render on each tick.
+      setRemainingSeconds(nextRemaining);
 
       if (nextRemaining <= 0) {
         if (timerIntervalRef.current) {
@@ -2804,7 +2795,8 @@ export default function App() {
   }, [timerActive, timerPaused, timerEndsAt]);
 
   const handleTogglePauseTimer = useCallback(() => {
-    if (!timerActive || timerRemainingSeconds === null) return;
+    const remaining = getRemainingSeconds();
+    if (!timerActive || remaining === null) return;
 
     if (timerIntervalRef.current) {
       clearInterval(timerIntervalRef.current);
@@ -2812,14 +2804,14 @@ export default function App() {
     }
 
     if (timerPaused) {
-      setTimerEndsAt(Date.now() + timerRemainingSeconds * 1000);
+      setTimerEndsAt(Date.now() + remaining * 1000);
       setTimerPaused(false);
       return;
     }
 
     setTimerEndsAt(null);
     setTimerPaused(true);
-  }, [timerActive, timerPaused, timerRemainingSeconds]);
+  }, [timerActive, timerPaused]);
 
   // Celebration listener (fired by awardXp when goal is reached)
   useEffect(() => {
@@ -5604,10 +5596,9 @@ export default function App() {
           onSelectTab={handleSelectTab}
           viewMode={viewMode}
           // 🆕 timer props
-          timerRemainingSeconds={timerRemainingSeconds}
+          hasTimer={hasTimer}
           isTimerRunning={isTimerRunning}
           timerPaused={timerPaused}
-          formatTimer={formatTimer}
           onOpenTimerModal={() => setTimerModalOpen(true)}
           onTogglePauseTimer={handleTogglePauseTimer}
           onOpenDailyGoalModal={() => setDailyGoalOpen(true)}
@@ -5997,7 +5988,7 @@ export default function App() {
         onMinutesChange={setTimerMinutes}
         onStart={handleStartTimer}
         isRunning={isTimerRunning}
-        helper={timerHelper}
+        helper={null}
         t={t}
       />
 

--- a/nosabos/src/App.jsx
+++ b/nosabos/src/App.jsx
@@ -2707,8 +2707,11 @@ export default function App() {
     setHasTimer(false);
   }, []);
 
-  const handleStartTimer = useCallback(() => {
-    const parsedMinutes = Math.max(1, Math.round(Number(timerMinutes) || 0));
+  const handleStartTimer = useCallback((minutesArg) => {
+    // The modal may pass its local draft value here — prefer it over the
+    // parent state to avoid any staleness if the user hadn't blurred yet.
+    const source = minutesArg ?? timerMinutes;
+    const parsedMinutes = Math.max(1, Math.round(Number(source) || 0));
     handleResetTimer();
     const seconds = parsedMinutes * 60;
     const endsAt = Date.now() + seconds * 1000;

--- a/nosabos/src/App.jsx
+++ b/nosabos/src/App.jsx
@@ -2707,27 +2707,30 @@ export default function App() {
     setHasTimer(false);
   }, []);
 
-  const handleStartTimer = useCallback((minutesArg) => {
-    // The modal may pass its local draft value here — prefer it over the
-    // parent state to avoid any staleness if the user hadn't blurred yet.
-    const source = minutesArg ?? timerMinutes;
-    const parsedMinutes = Math.max(1, Math.round(Number(source) || 0));
-    handleResetTimer();
-    const seconds = parsedMinutes * 60;
-    const endsAt = Date.now() + seconds * 1000;
-    setTimerDurationSeconds(seconds);
-    setRemainingSeconds(seconds);
-    setTimerActive(true);
-    setTimerPaused(false);
-    setTimerEndsAt(endsAt);
-    setTimeUpOpen(false);
-    setTimerModalOpen(false);
-    setHasTimer(true);
-    if (shouldShowProficiencyAfterTimer) {
-      setShouldShowProficiencyAfterTimer(false);
-      setProficiencyTestOpen(true);
-    }
-  }, [handleResetTimer, timerMinutes, shouldShowProficiencyAfterTimer]);
+  const handleStartTimer = useCallback(
+    (minutesArg) => {
+      // The modal may pass its local draft value here — prefer it over the
+      // parent state to avoid any staleness if the user hadn't blurred yet.
+      const source = minutesArg ?? timerMinutes;
+      const parsedMinutes = Math.max(1, Math.round(Number(source) || 0));
+      handleResetTimer();
+      const seconds = parsedMinutes * 60;
+      const endsAt = Date.now() + seconds * 1000;
+      setTimerDurationSeconds(seconds);
+      setRemainingSeconds(seconds);
+      setTimerActive(true);
+      setTimerPaused(false);
+      setTimerEndsAt(endsAt);
+      setTimeUpOpen(false);
+      setTimerModalOpen(false);
+      setHasTimer(true);
+      if (shouldShowProficiencyAfterTimer) {
+        setShouldShowProficiencyAfterTimer(false);
+        setProficiencyTestOpen(true);
+      }
+    },
+    [handleResetTimer, timerMinutes, shouldShowProficiencyAfterTimer],
+  );
 
   const handleCloseTimeUp = useCallback(() => {
     playSound(selectSound);

--- a/nosabos/src/components/SessionTimerBadge.jsx
+++ b/nosabos/src/components/SessionTimerBadge.jsx
@@ -1,0 +1,27 @@
+import { Badge, Text } from "@chakra-ui/react";
+import {
+  formatTimer,
+  useSessionTimerRemaining,
+} from "../provider/SessionTimerProvider";
+
+export default function SessionTimerBadge({ isRunning }) {
+  const remaining = useSessionTimerRemaining();
+  if (remaining === null) return null;
+
+  return (
+    <Badge
+      colorScheme={isRunning ? "teal" : "purple"}
+      variant="subtle"
+      px={3}
+      py={1.5}
+      borderRadius="md"
+      display="flex"
+      alignItems="center"
+      gap={2}
+    >
+      <Text fontFamily="mono" fontWeight="bold" fontSize="2xs">
+        {formatTimer(remaining)}
+      </Text>
+    </Badge>
+  );
+}

--- a/nosabos/src/components/SessionTimerModal.jsx
+++ b/nosabos/src/components/SessionTimerModal.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useCallback, useRef, useEffect } from "react";
+import React, { useMemo, useCallback, useRef, useEffect, useState } from "react";
 import {
   Box,
   Button,
@@ -458,6 +458,22 @@ export default function SessionTimerModal({
   const playSliderTick = useSoundSettings((s) => s.playSliderTick);
   const themeMode = useThemeStore((s) => s.themeMode);
   const isLightTheme = themeMode === "light";
+
+  // Local draft so the input and clock are instantly responsive without
+  // waiting for the parent App re-render to round-trip back.
+  const [localMinutes, setLocalMinutes] = useState(() => minutes);
+  useEffect(() => {
+    if (isOpen) setLocalMinutes(minutes);
+  }, [isOpen]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handleLocalMinutesChange = useCallback(
+    (value) => {
+      setLocalMinutes(value);
+      onMinutesChange?.(value);
+    },
+    [onMinutesChange],
+  );
+
   const handleClose = useCallback(() => {
     playSound(selectSound);
     onClose?.();
@@ -518,8 +534,8 @@ export default function SessionTimerModal({
 
             {/* Clock visual — drag around the face to adjust time */}
             <ClockVisual
-              minutes={minutes}
-              onMinutesChange={onMinutesChange}
+              minutes={localMinutes}
+              onMinutesChange={handleLocalMinutesChange}
               playSliderTick={playSliderTick}
               isLightTheme={isLightTheme}
             />
@@ -534,13 +550,13 @@ export default function SessionTimerModal({
                 type="number"
                 min={0}
                 max={240}
-                value={minutes}
+                value={localMinutes}
                 onChange={(e) => {
                   const val = Number(e.target.value);
                   if (val > 240) {
-                    onMinutesChange?.("240");
+                    handleLocalMinutesChange("240");
                   } else {
-                    onMinutesChange?.(e.target.value);
+                    handleLocalMinutesChange(e.target.value);
                   }
                 }}
                 bg={isLightTheme ? APP_SURFACE : "gray.800"}
@@ -575,7 +591,7 @@ export default function SessionTimerModal({
               </Text>
               <HStack spacing={2} wrap="wrap">
                 {presets.map((preset) => {
-                  const isActive = Number(minutes) === preset;
+                  const isActive = Number(localMinutes) === preset;
                   return (
                     <Button
                       key={preset}
@@ -620,7 +636,7 @@ export default function SessionTimerModal({
                       }
                       onClick={() => {
                         playSound(selectSound);
-                        onMinutesChange?.(String(preset));
+                        handleLocalMinutesChange(String(preset));
                       }}
                     >
                       {preset}m

--- a/nosabos/src/components/SessionTimerModal.jsx
+++ b/nosabos/src/components/SessionTimerModal.jsx
@@ -459,38 +459,31 @@ export default function SessionTimerModal({
   const themeMode = useThemeStore((s) => s.themeMode);
   const isLightTheme = themeMode === "light";
 
-  // Local draft so the input and clock are instantly responsive without
-  // waiting for the parent App re-render to round-trip back.
+  // All editing (typing, presets, clock drag) updates only this local draft
+  // so interactions stay instant. The parent App is synced at commit points:
+  // close and start. This avoids an App re-render on every drag tick or
+  // preset click.
   const [localMinutes, setLocalMinutes] = useState(() => minutes);
   useEffect(() => {
     if (isOpen) setLocalMinutes(minutes);
   }, [isOpen]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Used by presets and clock drag — commits the value to the parent too.
-  const handleLocalMinutesChange = useCallback(
-    (value) => {
-      setLocalMinutes(value);
-      onMinutesChange?.(value);
-    },
-    [onMinutesChange],
-  );
+  const handleLocalMinutesChange = useCallback((value) => {
+    setLocalMinutes(value);
+  }, []);
 
-  // Typing only updates local state so each keystroke stays instant.
-  // The parent is synced on blur and on Start.
   const handleInputChange = useCallback((e) => {
     const raw = e.target.value;
     const val = Number(raw);
     setLocalMinutes(val > 240 ? "240" : raw);
   }, []);
 
-  const handleInputBlur = useCallback(() => {
-    onMinutesChange?.(localMinutes);
-  }, [onMinutesChange, localMinutes]);
-
   const handleClose = useCallback(() => {
+    onMinutesChange?.(localMinutes);
     playSound(selectSound);
     onClose?.();
-  }, [onClose, playSound]);
+  }, [onClose, onMinutesChange, localMinutes, playSound]);
+
   const handleStart = useCallback(() => {
     onMinutesChange?.(localMinutes);
     onStart?.(localMinutes);
@@ -566,7 +559,6 @@ export default function SessionTimerModal({
                 max={240}
                 value={localMinutes}
                 onChange={handleInputChange}
-                onBlur={handleInputBlur}
                 bg={isLightTheme ? APP_SURFACE : "gray.800"}
                 color={isLightTheme ? APP_TEXT_PRIMARY : undefined}
                 borderColor={isLightTheme ? APP_BORDER_STRONG : "gray.600"}

--- a/nosabos/src/components/SessionTimerModal.jsx
+++ b/nosabos/src/components/SessionTimerModal.jsx
@@ -466,6 +466,7 @@ export default function SessionTimerModal({
     if (isOpen) setLocalMinutes(minutes);
   }, [isOpen]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Used by presets and clock drag — commits the value to the parent too.
   const handleLocalMinutesChange = useCallback(
     (value) => {
       setLocalMinutes(value);
@@ -474,14 +475,27 @@ export default function SessionTimerModal({
     [onMinutesChange],
   );
 
+  // Typing only updates local state so each keystroke stays instant.
+  // The parent is synced on blur and on Start.
+  const handleInputChange = useCallback((e) => {
+    const raw = e.target.value;
+    const val = Number(raw);
+    setLocalMinutes(val > 240 ? "240" : raw);
+  }, []);
+
+  const handleInputBlur = useCallback(() => {
+    onMinutesChange?.(localMinutes);
+  }, [onMinutesChange, localMinutes]);
+
   const handleClose = useCallback(() => {
     playSound(selectSound);
     onClose?.();
   }, [onClose, playSound]);
   const handleStart = useCallback(() => {
-    onStart?.();
+    onMinutesChange?.(localMinutes);
+    onStart?.(localMinutes);
     void playSound(submitActionSound);
-  }, [onStart, playSound]);
+  }, [onMinutesChange, onStart, localMinutes, playSound]);
 
   return (
     <Modal
@@ -551,14 +565,8 @@ export default function SessionTimerModal({
                 min={0}
                 max={240}
                 value={localMinutes}
-                onChange={(e) => {
-                  const val = Number(e.target.value);
-                  if (val > 240) {
-                    handleLocalMinutesChange("240");
-                  } else {
-                    handleLocalMinutesChange(e.target.value);
-                  }
-                }}
+                onChange={handleInputChange}
+                onBlur={handleInputBlur}
                 bg={isLightTheme ? APP_SURFACE : "gray.800"}
                 color={isLightTheme ? APP_TEXT_PRIMARY : undefined}
                 borderColor={isLightTheme ? APP_BORDER_STRONG : "gray.600"}

--- a/nosabos/src/provider/SessionTimerProvider.jsx
+++ b/nosabos/src/provider/SessionTimerProvider.jsx
@@ -1,0 +1,37 @@
+import { useSyncExternalStore } from "react";
+
+// Module-level store for the high-frequency "remaining seconds" value.
+// Keeping this out of React state prevents parent components (App, TopBar)
+// from re-rendering on every 1-second countdown tick — only subscribers do.
+let remainingValue = null;
+const subscribers = new Set();
+
+export function setRemainingSeconds(value) {
+  const normalized =
+    value === null || value === undefined ? null : Number(value);
+  if (remainingValue === normalized) return;
+  remainingValue = normalized;
+  subscribers.forEach((cb) => cb());
+}
+
+export function getRemainingSeconds() {
+  return remainingValue;
+}
+
+function subscribe(cb) {
+  subscribers.add(cb);
+  return () => {
+    subscribers.delete(cb);
+  };
+}
+
+export function useSessionTimerRemaining() {
+  return useSyncExternalStore(subscribe, getRemainingSeconds, () => null);
+}
+
+export function formatTimer(seconds) {
+  const safe = Math.max(0, Math.floor(Number(seconds) || 0));
+  const mins = String(Math.floor(safe / 60)).padStart(2, "0");
+  const secs = String(safe % 60).padStart(2, "0");
+  return `${mins}:${secs}`;
+}


### PR DESCRIPTION
## Summary
Refactored the session timer implementation to prevent unnecessary re-renders of the App and TopBar components on every 1-second countdown tick. The high-frequency "remaining seconds" value is now managed in a module-level store using React's `useSyncExternalStore`, allowing only the SessionTimerBadge component to re-render during countdown.

## Key Changes
- **Created SessionTimerProvider**: New module-level store (`SessionTimerProvider.jsx`) that manages the remaining seconds value outside of React state, with `setRemainingSeconds()`, `getRemainingSeconds()`, and `useSessionTimerRemaining()` utilities
- **Extracted SessionTimerBadge**: New component that subscribes to the external store and re-renders on each tick, while App and TopBar remain stable
- **Simplified App state**: Replaced `timerRemainingSeconds` state with a boolean `hasTimer` flag; remaining seconds are now only persisted to sessionStorage when paused
- **Updated TopBar props**: Changed from passing `timerRemainingSeconds` and `formatTimer` to just `hasTimer`, reducing prop coupling
- **Removed unused code**: Deleted the unused `timerHelper` useMemo and `formatTimer` callback from App

## Implementation Details
- The module-level store uses a Set of subscribers and notifies only them when the remaining seconds change, preventing parent component re-renders
- During active countdown, only the end time (`timerEndsAt`) is persisted; remaining seconds are recomputed on hydration
- During pause, the current remaining seconds are snapshotted to sessionStorage for reload persistence
- The `formatTimer` utility was moved to SessionTimerProvider for use by SessionTimerBadge

https://claude.ai/code/session_01QEwnWcycNR4f6tUQWhJwdL