### PR TITLE
Improve bottom action bar drawer open responsiveness

### DIFF
--- a/nosabos/src/App.jsx
+++ b/nosabos/src/App.jsx
@@ -5176,22 +5176,27 @@ export default function App() {
   }, [resolveNpub, setUser]);
 
   const handleOpenRealWorldTasks = useCallback(() => {
+    // Open immediately so the drawer animation starts on the next paint,
+    // then defer persistence work that can otherwise block the interaction.
     setRealWorldTasksOpen(true);
     setRealWorldTasksAttention(false);
-    const openedAt = new Date().toISOString();
-    patchUser({ realWorldTasksLastOpenedAt: openedAt });
-    if (activeNpub) {
-      setDoc(
-        doc(database, "users", activeNpub),
-        {
-          realWorldTasksLastOpenedAt: openedAt,
-          updatedAt: openedAt,
-        },
-        { merge: true },
-      ).catch((err) =>
-        console.warn("Failed to persist realWorldTasksLastOpenedAt:", err),
-      );
-    }
+
+    requestAnimationFrame(() => {
+      const openedAt = new Date().toISOString();
+      patchUser({ realWorldTasksLastOpenedAt: openedAt });
+      if (activeNpub) {
+        setDoc(
+          doc(database, "users", activeNpub),
+          {
+            realWorldTasksLastOpenedAt: openedAt,
+            updatedAt: openedAt,
+          },
+          { merge: true },
+        ).catch((err) =>
+          console.warn("Failed to persist realWorldTasksLastOpenedAt:", err),
+        );
+      }
+    });
   }, [activeNpub, patchUser]);
 
   // State for which CEFR level is currently being viewed (separate for each mode)
@@ -5487,7 +5492,9 @@ export default function App() {
   }, [activeLessonLevel, activeFlashcardLevel]);
 
   const handleBottomBarSettingsOpen = useCallback(() => {
-    setSettingsOpen(true);
+    // Yield one frame before opening to avoid coupling the tap with
+    // expensive work in the same event turn.
+    requestAnimationFrame(() => setSettingsOpen(true));
   }, []);
 
   /* -----------------------------------


### PR DESCRIPTION
### Motivation
- Users observed a perceptible lag between tapping the bottom action bar (Settings / Immersion) and the drawer animation starting, likely because synchronous side-effects were running in the same event turn and blocking the first animation frame.

### Description
- In `src/App.jsx` the immersion drawer opener `handleOpenRealWorldTasks` now calls `setRealWorldTasksOpen(true)` immediately and defers persistence side-effects (`patchUser` and Firestore `setDoc`) to the next frame using `requestAnimationFrame` to avoid blocking the interaction.
- The settings opener `handleBottomBarSettingsOpen` now defers the `setSettingsOpen(true)` call with `requestAnimationFrame` to decouple the tap event from heavier work in the same turn.
- Added short inline comments explaining the scheduling choices for interaction smoothness.

### Testing
- Ran `npm run build` and the production build completed successfully (Vite build passed with non-blocking warnings about chunk size and third-party libraries).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2e2804d508326b1ad58389dbb51dd)