### PR TITLE
Improve button hover/active states and quiz score calculation

### DIFF
--- a/nosabos/src/components/SkillTree.jsx
+++ b/nosabos/src/components/SkillTree.jsx
@@ -2209,8 +2209,9 @@ function LessonDetailModal({
                           ? `+${lesson.xpReward} XP`
                           : lesson.isFinalQuiz
                             ? `${Math.round(
-                                (lesson.quizConfig?.passingScore /
-                                  lesson.quizConfig?.questionsRequired) *
+                                ((lesson.quizConfig?.passingScore ?? 8) /
+                                  (lesson.quizConfig?.questionsRequired ??
+                                    10)) *
                                   100,
                               )}%`
                             : `+${lesson.xpReward} XP`}

--- a/nosabos/src/theme.js
+++ b/nosabos/src/theme.js
@@ -98,10 +98,23 @@ const duoSolid = defineStyle((props) => {
     getColor(theme, `${colorScheme}.500`) ??
     getColor(theme, "gray.500") ??
     "#4A5568";
+  const hoverBg =
+    getColor(theme, `${colorScheme}.600`) ?? darken(bg, 8) ?? bg;
+  const activeBg =
+    getColor(theme, `${colorScheme}.700`) ?? darken(bg, 16) ?? hoverBg;
 
   return {
     bg,
     color: "white",
+    _hover: {
+      bg: hoverBg,
+      color: "white",
+      _disabled: { bg },
+    },
+    _active: {
+      bg: activeBg,
+      color: "white",
+    },
   };
 });
 


### PR DESCRIPTION
## Summary
This PR enhances the UI/UX of the duo solid button style and fixes a potential bug in quiz score percentage calculation by adding proper fallback values.

## Key Changes
- **Button State Styling**: Added hover and active state styles to the `duoSolid` button variant
  - Hover state darkens the background by 8% with disabled state fallback
  - Active state darkens the background by 16% for better visual feedback
  - Both states maintain white text color for consistency

- **Quiz Score Calculation**: Fixed potential division by undefined values in the lesson detail modal
  - Added nullish coalescing operators (`??`) with sensible defaults
  - `passingScore` defaults to 8 if undefined
  - `questionsRequired` defaults to 10 if undefined
  - Prevents NaN results when quiz config values are missing

## Implementation Details
The button state improvements use the existing `darken` utility function to create a consistent color progression. The quiz calculation fix ensures the passing score percentage displays correctly even when quiz configuration is incomplete.

https://claude.ai/code/session_017kcYLP1rTWxrNqhXVXPQEK